### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ vars.DEFAULT_JAVA_DISTRIBUTION }}
           java-version: ${{ vars.DEFAULT_JAVA_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5.0.0
+        uses: gradle/actions/setup-gradle@v6.0.1
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ vars.DEFAULT_JAVA_DISTRIBUTION }}
           java-version: ${{ vars.DEFAULT_JAVA_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5.0.0
+        uses: gradle/actions/setup-gradle@v6.0.1
 
       - name: Build and Publish SNAPSHOT
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,16 +20,16 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Checkout sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Java
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ vars.DEFAULT_JAVA_DISTRIBUTION }}
           java-version: ${{ vars.DEFAULT_JAVA_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5.0.0
+        uses: gradle/actions/setup-gradle@v6.0.1
 
       - name: Build and Publish release
         env:
@@ -54,7 +54,7 @@ jobs:
           echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_ENV
 
       - name: Checkout target branch
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ env.TARGET_BRANCH }}
           fetch-depth: 0
@@ -63,7 +63,7 @@ jobs:
         run: ./gradlew -Pversion=$VERSION updateVersionsAfterRelease
 
       - name: Commit version updates after release
-        uses: stefanzweifel/git-auto-commit-action@v7.0.0
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
           commit_message: Version updated to ${{ env.VERSION }} in README.md, next snapshot in gradle.properties
           file_pattern: 'README.md gradle.properties'

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v7.1.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v7.1.0)** on 2025-12-17T19:25:45Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v6.0.1](https://github.com/gradle/actions/releases/tag/v6.0.1)** on 2026-03-24T16:07:52Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.2.0](https://github.com/actions/setup-java/releases/tag/v5.2.0)** on 2026-01-22T02:57:31Z
