### PR TITLE
Fix eagerly initialised derived values in XemanticConfiguration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@ see the [README](README.md#markdown-soft-wrapping-in-the-ide) for how to enable 
 - Gradle has two `Jar` task types — `org.gradle.api.tasks.bundling.Jar` *extends* `org.gradle.jvm.tasks.Jar`.
   Always match on the `jvm.tasks` supertype in `withType<Jar>()`, otherwise the match silently skips jars registered by other plugins:
   the javadoc jar of `com.vanniktech.maven.publish` extends the supertype, so matching on `bundling.Jar` published it without the manifest attributes and without `META-INF/LICENSE`.
+- The `xemantic` extension is instantiated while the plugin is being *applied*, so anything in `XemanticConfiguration` derived from its own properties or from `project.version` must be a computed property (`get() = …`), never an initialiser —
+  an initialiser captures the defaults, a still-null `inceptionYear` and an `unspecified` version, and silently keeps them while accepting the `xemantic { }` overrides without effect (issue #83).
+- Nullability is not part of a JVM signature, so widening a property from `String` to `String?` leaves `api/xemantic-conventions.api` unchanged — the `.api` dump is not a safety net for Kotlin-metadata-only ABI changes.
 - Never invoke `apiDump` together with `build` or `check` in a single Gradle run:
   `apiCheck` reads the file `apiDump` writes, and Gradle fails the run on the undeclared task dependency.
   Run `./gradlew apiDump` first, then `./gradlew build`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ mavenPublishing {
         name = rootProject.name
         description = xemantic.description
         inceptionYear = xemantic.inceptionYear.toString()
-        url = "https://github.com/${xemantic.gitHubAccount}}/${rootProject.name}"
+        url = "https://github.com/${xemantic.gitHubAccount}/${rootProject.name}"
 
         organization {
             name = xemantic.organization

--- a/src/main/kotlin/XemanticConfiguration.kt
+++ b/src/main/kotlin/XemanticConfiguration.kt
@@ -24,14 +24,12 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.withType
-import java.time.LocalDateTime
+import java.time.LocalDate
 import javax.inject.Inject
 
 public abstract class XemanticConfiguration @Inject constructor(
     private val project: Project
 ) {
-
-    private val now = LocalDateTime.now()
 
     public var description: String? = null
 
@@ -43,15 +41,41 @@ public abstract class XemanticConfiguration @Inject constructor(
 
     public var gitHubAccount: String = "xemantic"
 
-    public val url: String = "https://github.com/$gitHubAccount/${project.rootProject.name}"
+    /*
+     * Everything derived from the properties above must be a computed property, never an
+     * initializer. The extension is instantiated while the plugin is being applied, which is
+     * before the build script's `xemantic { }` block assigns anything, and before a build
+     * script assigning `version` has run. An initializer would capture the defaults - a still
+     * null `inceptionYear` and an `unspecified` project version - and silently keep them,
+     * accepting the `xemantic { }` overrides without effect. See issue #83.
+     */
 
-    public var copyright: String =
-            "© ${if (inceptionYear != now.year.toString()) "$inceptionYear-" else ""}${now.year} $organization"
+    public val url: String
+        get() = "https://github.com/$gitHubAccount/${project.rootProject.name}"
 
-    public val isReleaseBuild: Boolean = !(project.version as String).endsWith("-SNAPSHOT")
+    private var explicitCopyright: String? = null
 
-    public val releasePageUrl: String =
-        "https://github.com/$gitHubAccount/${project.rootProject.name}/releases/tag/v${project.version}"
+    /**
+     * The copyright notice, defaulting to `© <inceptionYear>-<currentYear> <organization>`,
+     * collapsed to a single year when the project was started in the current one.
+     *
+     * The current year is taken at read time, so that a long-lived Gradle daemon does not
+     * serve a stale notice across a New Year boundary.
+     */
+    public var copyright: String
+        get() = explicitCopyright ?: LocalDate.now().year.toString().let { currentYear ->
+            "© ${if (inceptionYear != currentYear) "$inceptionYear-" else ""}$currentYear $organization"
+        }
+        set(value) {
+            explicitCopyright = value
+        }
+
+    public val isReleaseBuild: Boolean
+        get() = !project.version.toString().endsWith("-SNAPSHOT")
+
+    public val releasePageUrl: String
+        get() = "https://github.com/$gitHubAccount/${project.rootProject.name}" +
+                "/releases/tag/v${project.version}"
 
     private fun validateParameters() {
         requireNotNull(description) { "description must be set" }

--- a/src/test/kotlin/functional/XemanticConfigurationFunctionalTest.kt
+++ b/src/test/kotlin/functional/XemanticConfigurationFunctionalTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.gradle.conventions.functional
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.time.LocalDate
+
+/**
+ * Verifies that the values derived by `xemantic { }` observe what the build script configured,
+ * rather than the defaults which are in place while the plugin is being applied.
+ *
+ * The probes read the properties at *configuration* time, into a local captured by the task
+ * action, which is both what a real build script does - `footerMessage.set(xemantic.copyright)` -
+ * and what keeps these fixtures compatible with the configuration cache.
+ *
+ * Regression test for issue #83, where the derived values were property initializers evaluated
+ * in the extension constructor.
+ */
+class XemanticConfigurationFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private lateinit var project: GradleProjectFixture
+
+    private val currentYear = LocalDate.now().year
+
+    @BeforeEach
+    fun setup() {
+        project = GradleProjectFixture(projectDir)
+        project.settings("repro")
+    }
+
+    private fun probeBuildScript(
+        version: String,
+        xemanticBlock: String
+    ) = project.file("build.gradle.kts", """
+        plugins {
+            id("com.xemantic.gradle.xemantic-conventions")
+        }
+
+        version = "$version"
+
+        xemantic {
+        $xemanticBlock
+        }
+
+        val probes = mapOf(
+            "url" to xemantic.url,
+            "copyright" to xemantic.copyright,
+            "releasePageUrl" to xemantic.releasePageUrl,
+            "isReleaseBuild" to xemantic.isReleaseBuild.toString()
+        )
+
+        tasks.register("probe") {
+            doLast {
+                probes.forEach { (name, value) -> println("${'$'}name = ${'$'}value") }
+            }
+        }
+    """)
+
+    @Test
+    fun `should derive url and releasePageUrl from the configured gitHubAccount and version`() {
+        // given
+        probeBuildScript(
+            version = "1.0.0",
+            xemanticBlock = """
+                description = "Repro"
+                inceptionYear = "2020"
+                gitHubAccount = "acme"
+                applyAllConventions()
+            """
+        )
+
+        // when
+        val result = project.build("probe")
+
+        // then
+        assert(result.output.contains("url = https://github.com/acme/repro")) { result.output }
+        assert(
+            result.output.contains(
+                "releasePageUrl = https://github.com/acme/repro/releases/tag/v1.0.0"
+            )
+        ) { result.output }
+    }
+
+    @Test
+    fun `should derive copyright from the configured inceptionYear and organization`() {
+        // given
+        probeBuildScript(
+            version = "1.0.0",
+            xemanticBlock = """
+                description = "Repro"
+                inceptionYear = "2020"
+                organization = "Acme"
+                applyAllConventions()
+            """
+        )
+
+        // when
+        val result = project.build("probe")
+
+        // then
+        assert(result.output.contains("copyright = © 2020-$currentYear Acme")) { result.output }
+    }
+
+    @Test
+    fun `should collapse copyright to a single year when the project started this year`() {
+        // given
+        probeBuildScript(
+            version = "1.0.0",
+            xemanticBlock = """
+                description = "Repro"
+                inceptionYear = "$currentYear"
+                applyAllConventions()
+            """
+        )
+
+        // when
+        val result = project.build("probe")
+
+        // then
+        assert(result.output.contains("copyright = © $currentYear Xemantic")) { result.output }
+    }
+
+    @Test
+    fun `should keep an explicitly assigned copyright`() {
+        // given
+        probeBuildScript(
+            version = "1.0.0",
+            xemanticBlock = """
+                description = "Repro"
+                inceptionYear = "2020"
+                copyright = "All rights reversed"
+                applyAllConventions()
+            """
+        )
+
+        // when
+        val result = project.build("probe")
+
+        // then
+        assert(result.output.contains("copyright = All rights reversed")) { result.output }
+    }
+
+    @Test
+    fun `should not report a release build for a version assigned by the build script`() {
+        // given
+        probeBuildScript(
+            version = "1.0.0-SNAPSHOT",
+            xemanticBlock = """
+                description = "Repro"
+                inceptionYear = "2020"
+                applyAllConventions()
+            """
+        )
+
+        // when
+        val result = project.build("probe")
+
+        // then
+        assert(result.output.contains("isReleaseBuild = false")) { result.output }
+    }
+
+    @Test
+    fun `should report a release build for a non snapshot version`() {
+        // given
+        probeBuildScript(
+            version = "1.0.0",
+            xemanticBlock = """
+                description = "Repro"
+                inceptionYear = "2020"
+                applyAllConventions()
+            """
+        )
+
+        // when
+        val result = project.build("probe")
+
+        // then
+        assert(result.output.contains("isReleaseBuild = true")) { result.output }
+    }
+
+}


### PR DESCRIPTION
Fixes #83.

## Problem

`url`, `copyright`, `releasePageUrl` and `isReleaseBuild` were property *initialisers*, evaluated once when `project.extensions.create(...)` runs during plugin application — before the build script's `xemantic { }` block assigns anything, and before a build script assigning `version` has run.

They captured the defaults and kept them for the rest of the build, accepting the `xemantic { }` overrides without error and without effect:

| Property | Captured |
|---|---|
| `url` | default `gitHubAccount` = `xemantic` |
| `copyright` | `inceptionYear` = `null` → `© null-<year>` |
| `isReleaseBuild` | `version` = `unspecified` → **`true`** |
| `releasePageUrl` | default account + `vunspecified` |

`copyright` and `isReleaseBuild` did not even need an override to go wrong. `© null-…` appeared in *every* project, since there is no point at which a build script could set `inceptionYear` early enough — including this repository's own Dokka footer, and anything generated from `xemantic-project-template`. `isReleaseBuild` failed toward "this is a release build"; only the template's convention of setting `version` in `gradle.properties`, which Gradle applies before plugin application, kept that from surfacing.

## Fix

All four become computed properties, observing the configured state at read time.

`copyright` stays assignable via a private backing field rather than the `String?` widening suggested in the issue — this keeps the non-null type, so no source break for consumers. Worth recording: the `.api` dump would **not** have caught the `String?` change either way, since nullability is absent from JVM signatures (`getCopyright ()Ljava/lang/String;`). `apiDump` was re-run and is unchanged.

The current year is now taken at read time too, so a long-lived daemon cannot serve a stale notice across a New Year boundary. And `project.version` is read via `toString()` rather than `as String`, which is not guaranteed for a build script assigning anything else.

The issue's other knock-on note — requiring `inceptionYear` in `validate()` — turned out to already hold; `validateParameters()` has that `requireNotNull`.

## Aside

Also fixes the stray brace at `build.gradle.kts:126`, which published a POM `url` of `https://github.com/xemantic}/xemantic-conventions`. The neighbouring `scm`/`ciManagement`/`issueManagement` blocks were already correct.

## Verification

New `XemanticConfigurationFunctionalTest` covers each derived value through a real TestKit build. It reads the properties at configuration time into a local captured by the task action — what a real build script does with `footerMessage.set(xemantic.copyright)`, and configuration-cache-safe.

Checked against the unfixed source: **4 of the 6 cases fail**. The two that pass are `should keep an explicitly assigned copyright` (the setter always worked) and `should report a release build for a non snapshot version` — which passed for the wrong reason, since `unspecified` also yielded `true`. The `-SNAPSHOT` counterpart is what pins that behaviour down.

`./gradlew build` is green.

## Not addressed here

`configureJReleaserConventions` reads `config.copyright` and `config.description` eagerly, at the moment `applyJReleaserConventions()` is called. Under the documented usage — `applyAllConventions()` last in the `xemantic { }` block — this is now correct, but it stays sensitive to ordering within the block. Making those `project.provider { }` (the pattern `populateJarManifest` already uses) would close that, though I left it out: it is not verifiable locally, because `publishToMavenCentral` only exists when Maven Central publishing is enabled. Happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
